### PR TITLE
ci: fix publish push from detached HEAD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,7 +140,9 @@ jobs:
           git add package.json
           git commit -m "chore: bump version to ${{ steps.ensure.outputs.final_version }}"
           git tag v${{ steps.ensure.outputs.final_version }}
-          git push origin main --tags
+          # We are on a detached HEAD (merge commit). Push the commit to main explicitly and push tags.
+          git push origin HEAD:refs/heads/main
+          git push origin --tags
 
       - name: Create GitHub Release
         if: steps.version.outputs.bump != 'none'


### PR DESCRIPTION
- push HEAD->main and tags in publish job\n- ensure unique npm version via patch auto-bump\n- checkout merge commit and fetch tags\n- add concurrency guard