### PR TITLE
feat: add bulk VSIX install flow, mismatch safeguards, and docs

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,0 +1,723 @@
+import * as p from "@clack/prompts";
+import path from "path";
+import fs from "fs-extra";
+import {
+  getEditorService,
+  getVsixScanner,
+  getInstallService,
+  getInstallFromListService,
+} from "../features/install";
+import { DEFAULT_OUTPUT_DIR } from "../config/constants";
+
+interface InstallOptions {
+  // Input sources
+  vsix?: string; // Single VSIX file
+  vsixDir?: string | string[]; // Directory/directories to scan for VSIX files
+  file?: string; // Extension list file (.txt or extensions.json)
+
+  // Download behavior when installing from list
+  downloadMissing?: boolean;
+
+  // Editor targeting
+  editor?: string; // vscode | cursor | auto
+  codeBin?: string; // Explicit VS Code binary path
+  cursorBin?: string; // Explicit Cursor binary path
+
+  // Install behavior
+  skipInstalled?: boolean;
+  forceReinstall?: boolean;
+  dryRun?: boolean;
+
+  // Parallelism and retries
+  parallel?: number | string;
+  retry?: number | string;
+  retryDelay?: number | string;
+
+  // Output control
+  quiet?: boolean;
+  json?: boolean;
+  summary?: string;
+  allowMismatchedBinary?: boolean;
+
+  // Config values (merged in)
+  installParallel?: number;
+  installRetry?: number;
+  installRetryDelay?: number;
+  outputDir?: string;
+  cacheDir?: string;
+  source?: string;
+  preRelease?: boolean;
+
+  // Legacy compatibility
+  output?: string;
+}
+
+export async function installExtensions(options: InstallOptions) {
+  console.clear();
+
+  p.intro("⚙️  VSIX Extension Manager - Install");
+
+  try {
+    // Determine install mode (interactive if no clear mode provided)
+    const installMode = determineInstallMode(options);
+
+    switch (installMode) {
+      case "single-vsix":
+        await installSingleVsix(options);
+        break;
+      case "vsix-directory":
+        await installFromVsixDirectory(options);
+        break;
+      case "from-list":
+        await installFromList(options);
+        break;
+      default:
+        await interactiveInstallMode(options);
+    }
+  } catch (error) {
+    p.log.error("❌ Error: " + (error instanceof Error ? error.message : String(error)));
+    process.exit(1);
+  }
+}
+
+function determineInstallMode(options: InstallOptions): string {
+  if (options.vsix) return "single-vsix";
+  if (options.vsixDir) return "vsix-directory";
+  if (options.file) return "from-list";
+  return "interactive";
+}
+
+function normalizeVsixDirs(vsixDir?: string | string[]): string[] {
+  if (!vsixDir) return [];
+  return Array.isArray(vsixDir) ? vsixDir : [vsixDir];
+}
+
+function detectIdentityFromPath(pth: string): "vscode" | "cursor" | "unknown" {
+  const lower = pth.toLowerCase();
+  if (lower.includes("cursor.app")) return "cursor";
+  if (lower.includes("visual studio code.app")) return "vscode";
+  if (/(^|[\\/])cursor([\\/]|$)/.test(lower)) return "cursor";
+  if (/(^|[\\/])code([\\/]|$)/.test(lower)) return "vscode";
+  return "unknown";
+}
+
+function getIdentityBadge(expected: "vscode" | "cursor", binaryPath: string): string {
+  const identity = detectIdentityFromPath(binaryPath);
+  if (identity === "unknown") return "";
+  return identity === expected ? " — OK" : " — MISMATCH";
+}
+
+async function interactiveInstallMode(options: InstallOptions) {
+  const mode = await p.select({
+    message: "Choose install mode:",
+    options: [
+      {
+        value: "single-vsix",
+        label: "Install single VSIX file",
+        hint: "Install one .vsix file into VS Code or Cursor",
+      },
+      {
+        value: "vsix-directory",
+        label: "Install all VSIX files from directory",
+        hint: "Scan and install multiple .vsix files",
+      },
+      {
+        value: "from-list",
+        label: "Install from extension list",
+        hint: "Install from .txt file or extensions.json",
+      },
+    ],
+  });
+
+  if (p.isCancel(mode)) {
+    p.cancel("Operation cancelled.");
+    process.exit(0);
+  }
+
+  switch (mode) {
+    case "single-vsix":
+      await installSingleVsix(options);
+      break;
+    case "vsix-directory":
+      await installFromVsixDirectory(options);
+      break;
+    case "from-list":
+      await installFromList(options);
+      break;
+  }
+}
+
+async function installSingleVsix(options: InstallOptions) {
+  let vsixPath = options.vsix;
+
+  if (!vsixPath) {
+    const result = await p.text({
+      message: "Enter path to VSIX file:",
+      validate: (input: string) => {
+        if (!input.trim()) return "Please enter a VSIX file path";
+        if (!fs.existsSync(input.trim())) return "File does not exist";
+        if (!input.toLowerCase().endsWith(".vsix")) return "File must be a .vsix file";
+        return undefined;
+      },
+    });
+
+    if (p.isCancel(result)) {
+      p.cancel("Operation cancelled.");
+      process.exit(0);
+    }
+
+    vsixPath = result as string;
+  }
+
+  // Validate VSIX file exists
+  if (!fs.existsSync(vsixPath!)) {
+    p.log.error(`❌ VSIX file not found: ${vsixPath}`);
+    process.exit(1);
+  }
+
+  const editor = await resolveEditor(options);
+  const binPath = await resolveEditorBinary(editor, options);
+  // Preflight
+  const preflight = await getInstallService().validatePrerequisites(binPath);
+  if (!preflight.valid) {
+    p.log.error("❌ Preflight checks failed:");
+    preflight.errors.forEach((e) => p.log.error(`  • ${e}`));
+    process.exit(1);
+  }
+
+  p.note(`VSIX: ${vsixPath}\nEditor: ${editor}\nBinary: ${binPath}`, "Install Details");
+
+  if (!options.quiet && !options.json) {
+    const confirmRes = await p.confirm({
+      message: "Proceed with installation?",
+      initialValue: true,
+    });
+    if (p.isCancel(confirmRes) || !confirmRes) {
+      p.cancel("Installation cancelled.");
+      return;
+    }
+  }
+
+  // Perform installation
+  const installService = getInstallService();
+  const spinner = p.spinner();
+  spinner.start("Installing VSIX file...");
+
+  try {
+    const result = await installService.installSingleVsix(binPath, vsixPath, {
+      dryRun: options.dryRun,
+      forceReinstall: options.forceReinstall,
+      timeout: 30000,
+    });
+
+    if (result.success) {
+      spinner.stop("✅ Installation successful!");
+      p.note(`File: ${vsixPath}\nExit Code: ${result.exitCode}`, "Install Result");
+    } else {
+      spinner.stop("❌ Installation failed", 1);
+      p.note(
+        `File: ${vsixPath}\nExit Code: ${result.exitCode}\nError: ${result.error || "Unknown error"}`,
+        "Install Result",
+      );
+    }
+  } catch (error) {
+    spinner.stop("❌ Installation failed", 1);
+    throw error;
+  }
+
+  // JSON/stdout and summary support
+  const summaryData = {
+    timestamp: new Date().toISOString(),
+    file: vsixPath,
+    editor,
+    binary: binPath,
+    dryRun: Boolean(options.dryRun),
+  };
+  if (options.summary) {
+    try {
+      await fs.writeJson(options.summary, summaryData, { spaces: 2 });
+      if (!options.quiet && !options.json) {
+        p.log.success(`📄 Summary written to: ${options.summary}`);
+      }
+    } catch (error) {
+      if (!options.quiet)
+        p.log.warn(
+          `⚠️ Failed to write summary: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+  }
+  if (options.json) {
+    console.log(JSON.stringify(summaryData, null, 2));
+  } else if (!options.quiet) {
+    p.outro("✅ Installation completed!");
+  }
+}
+
+async function installFromVsixDirectory(options: InstallOptions) {
+  let scanDirs = normalizeVsixDirs(options.vsixDir);
+
+  if (scanDirs.length === 0) {
+    const result = await p.text({
+      message: "Enter directory to scan for VSIX files:",
+      placeholder: "./downloads",
+      initialValue: DEFAULT_OUTPUT_DIR,
+      validate: (input: string) => {
+        if (!input.trim()) return "Please enter a directory path";
+        if (!fs.existsSync(input.trim())) return "Directory does not exist";
+        return undefined;
+      },
+    });
+
+    if (p.isCancel(result)) {
+      p.cancel("Operation cancelled.");
+      process.exit(0);
+    }
+
+    scanDirs = [result as string];
+  }
+
+  // Validate all directories exist
+  for (const scanDir of scanDirs) {
+    if (!fs.existsSync(scanDir)) {
+      p.log.error(`❌ Directory not found: ${scanDir}`);
+      process.exit(1);
+    }
+  }
+
+  const editor = await resolveEditor(options);
+  const binPath = await resolveEditorBinary(editor, options);
+  // Preflight
+  const preflight = await getInstallService().validatePrerequisites(binPath);
+  if (!preflight.valid) {
+    p.log.error("❌ Preflight checks failed:");
+    preflight.errors.forEach((e) => p.log.error(`  • ${e}`));
+    process.exit(1);
+  }
+
+  // Scan for VSIX files in all directories
+  const vsixScanner = getVsixScanner();
+  const installService = getInstallService();
+
+  const spinner = p.spinner();
+  spinner.start("Scanning for VSIX files...");
+
+  try {
+    const allValidVsix = [];
+    const allInvalidFiles = [];
+    let totalFiles = 0;
+
+    for (const scanDir of scanDirs) {
+      const scanResult = await vsixScanner.scanDirectory(scanDir);
+      allValidVsix.push(...scanResult.validVsixFiles);
+      allInvalidFiles.push(...scanResult.invalidFiles);
+      totalFiles += scanResult.totalFiles;
+    }
+
+    const combinedScanResult = {
+      totalFiles,
+      validVsixFiles: allValidVsix,
+      invalidFiles: allInvalidFiles,
+      errors: [],
+    };
+
+    spinner.stop(`Found ${combinedScanResult.validVsixFiles.length} VSIX file(s)`);
+
+    if (combinedScanResult.validVsixFiles.length === 0) {
+      p.log.warn("⚠️ No valid VSIX files found in the directories");
+      return;
+    }
+
+    // Show scan summary
+    const summary = vsixScanner.getScanSummary(combinedScanResult);
+    p.note(
+      `Total: ${summary.total}\nValid: ${summary.valid}\nInvalid: ${summary.invalid}\nUnique Extensions: ${summary.uniqueExtensions}`,
+      "Scan Summary",
+    );
+
+    if (combinedScanResult.invalidFiles.length > 0) {
+      p.log.warn(`⚠️ ${combinedScanResult.invalidFiles.length} invalid file(s) found:`);
+      combinedScanResult.invalidFiles.forEach((file) => {
+        p.log.warn(`  • ${file.filename}: ${file.error}`);
+      });
+    }
+
+    // Confirm installation (skip in quiet/json mode)
+    if (!options.quiet && !options.json) {
+      const shouldProceed = await p.confirm({
+        message: `Install ${combinedScanResult.validVsixFiles.length} VSIX file(s)?`,
+        initialValue: true,
+      });
+
+      if (p.isCancel(shouldProceed) || !shouldProceed) {
+        p.cancel("Installation cancelled.");
+        return;
+      }
+    }
+
+    // Create install tasks
+    const installTasks = combinedScanResult.validVsixFiles.map((vsixFile) => ({
+      vsixFile,
+      extensionId: vsixFile.extensionId,
+      targetVersion: vsixFile.version,
+    }));
+
+    // Perform bulk installation
+    spinner.start("Installing VSIX files...");
+    const installResult = await installService.installBulkVsix(
+      binPath,
+      installTasks,
+      {
+        dryRun: options.dryRun,
+        forceReinstall: options.forceReinstall,
+        skipInstalled: options.skipInstalled,
+        parallel: Number(options.parallel) || options.installParallel || 1,
+        retry: Number(options.retry) || options.installRetry || 2,
+        retryDelay: Number(options.retryDelay) || options.installRetryDelay || 1000,
+        timeout: 30000,
+        quiet: options.quiet,
+      },
+      (result) => {
+        if (!options.quiet) {
+          const status = result.success ? "✅" : result.skipped ? "⏭️" : "❌";
+          const filename = path.basename(result.task.vsixFile.path);
+          spinner.message(`${status} ${filename}`);
+        }
+      },
+    );
+
+    spinner.stop(`Installation completed!`);
+
+    // Show results
+    p.note(
+      `Total: ${installResult.total}\nSuccessful: ${installResult.successful}\nSkipped: ${installResult.skipped}\nFailed: ${installResult.failed}\nDuration: ${Math.round(installResult.elapsedMs / 1000)}s`,
+      "Install Summary",
+    );
+
+    if (installResult.failed > 0 && !options.quiet) {
+      p.log.error("❌ Failed installations:");
+      installResult.results
+        .filter((r) => !r.success && !r.skipped)
+        .forEach((result) => {
+          p.log.error(`  • ${path.basename(result.task.vsixFile.path)}: ${result.error}`);
+        });
+    }
+
+    // Write summary JSON if requested
+    if (options.summary) {
+      try {
+        const summaryData = {
+          timestamp: new Date().toISOString(),
+          scanResult: {
+            totalFiles: combinedScanResult.totalFiles,
+            validVsixFiles: combinedScanResult.validVsixFiles.length,
+            invalidFiles: combinedScanResult.invalidFiles.length,
+          },
+          installResult: {
+            total: installResult.total,
+            successful: installResult.successful,
+            skipped: installResult.skipped,
+            failed: installResult.failed,
+            elapsedMs: installResult.elapsedMs,
+            results: installResult.results.map((r) => ({
+              filename: path.basename(r.task.vsixFile.path),
+              extensionId: r.task.extensionId,
+              version: r.task.targetVersion,
+              success: r.success,
+              skipped: r.skipped,
+              error: r.error,
+              elapsedMs: r.elapsedMs,
+            })),
+          },
+        };
+
+        await fs.writeJson(options.summary, summaryData, { spaces: 2 });
+        if (!options.quiet) {
+          p.log.success(`📄 Summary written to: ${options.summary}`);
+        }
+      } catch (error) {
+        p.log.warn(
+          `⚠️ Failed to write summary: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  } catch (error) {
+    spinner.stop("❌ Installation failed", 1);
+    throw error;
+  }
+
+  p.outro("✅ Bulk installation completed!");
+}
+
+async function installFromList(options: InstallOptions) {
+  let listPath = options.file;
+
+  if (!listPath) {
+    const result = await p.text({
+      message: "Enter path to extension list file:",
+      validate: (input: string) => {
+        if (!input.trim()) return "Please enter a file path";
+        if (!fs.existsSync(input.trim())) return "File does not exist";
+        return undefined;
+      },
+    });
+
+    if (p.isCancel(result)) {
+      p.cancel("Operation cancelled.");
+      process.exit(0);
+    }
+
+    listPath = result as string;
+  }
+
+  // Validate file exists
+  if (!fs.existsSync(listPath!)) {
+    p.log.error(`❌ File not found: ${listPath}`);
+    process.exit(1);
+  }
+
+  const editor = await resolveEditor(options);
+  const binPath = await resolveEditorBinary(editor, options);
+  // Preflight
+  const preflight = await getInstallService().validatePrerequisites(binPath);
+  if (!preflight.valid) {
+    p.log.error("❌ Preflight checks failed:");
+    preflight.errors.forEach((e) => p.log.error(`  • ${e}`));
+    process.exit(1);
+  }
+
+  // Determine VSIX search directories
+  let vsixSearchDirs = normalizeVsixDirs(options.vsixDir);
+  if (vsixSearchDirs.length === 0) {
+    vsixSearchDirs = [options.outputDir || options.output || DEFAULT_OUTPUT_DIR];
+  }
+  // Always include cache directory if specified
+  if (options.cacheDir && !vsixSearchDirs.includes(options.cacheDir)) {
+    vsixSearchDirs.unshift(options.cacheDir);
+  }
+  // Include output directory if not already present
+  const outputDir = options.outputDir || options.output || DEFAULT_OUTPUT_DIR;
+  if (!vsixSearchDirs.includes(outputDir)) {
+    vsixSearchDirs.push(outputDir);
+  }
+
+  // Install from list
+  const installFromListService = getInstallFromListService();
+
+  const spinner = p.spinner();
+  spinner.start("Processing extension list...");
+
+  try {
+    const result = await installFromListService.installFromList(
+      binPath,
+      listPath,
+      vsixSearchDirs,
+      {
+        downloadMissing: options.downloadMissing,
+        downloadOptions: {
+          outputDir: options.outputDir || options.output,
+          cacheDir: options.cacheDir,
+          source:
+            options.source === "auto"
+              ? undefined
+              : (options.source as "marketplace" | "open-vsx" | undefined),
+          preRelease: options.preRelease,
+          quiet: options.quiet,
+          parallel: options.parallel,
+          retry: options.retry,
+          retryDelay: options.retryDelay,
+        },
+        installOptions: {
+          dryRun: options.dryRun,
+          forceReinstall: options.forceReinstall,
+          skipInstalled: options.skipInstalled,
+          parallel: Number(options.parallel) || options.installParallel || 1,
+          retry: Number(options.retry) || options.installRetry || 2,
+          retryDelay: Number(options.retryDelay) || options.installRetryDelay || 1000,
+          timeout: 30000,
+          quiet: options.quiet,
+        },
+      },
+      (message) => {
+        if (!options.quiet) {
+          spinner.message(message);
+        }
+      },
+    );
+
+    spinner.stop("Installation completed!");
+
+    // Show results
+    p.note(
+      `Total Extensions: ${result.totalExtensions}\nVSIX Files Found: ${result.foundVsixFiles}\nDownloaded: ${result.downloadedExtensions}\nInstalled: ${result.installedExtensions}\nSkipped: ${result.skippedExtensions}\nFailed: ${result.failedExtensions}`,
+      "Install Summary",
+    );
+
+    if (result.downloadResult && !options.quiet) {
+      p.note(
+        `Downloaded: ${result.downloadResult.successful}\nDownload Failed: ${result.downloadResult.failed}`,
+        "Download Summary",
+      );
+    }
+
+    if (result.errors.length > 0) {
+      p.log.error("❌ Errors encountered:");
+      result.errors.forEach((error) => {
+        p.log.error(`  • ${error}`);
+      });
+    }
+
+    if (result.installResult.failed > 0 && !options.quiet) {
+      p.log.error("❌ Failed installations:");
+      result.installResult.results
+        .filter((r) => !r.success && !r.skipped)
+        .forEach((result) => {
+          const filename = result.task.vsixFile
+            ? path.basename(result.task.vsixFile.path)
+            : result.task.extensionId || "unknown";
+          p.log.error(`  • ${filename}: ${result.error}`);
+        });
+    }
+
+    // Write summary JSON if requested
+    if (options.summary) {
+      try {
+        const summaryData = {
+          timestamp: new Date().toISOString(),
+          totalExtensions: result.totalExtensions,
+          foundVsixFiles: result.foundVsixFiles,
+          downloadedExtensions: result.downloadedExtensions,
+          installedExtensions: result.installedExtensions,
+          skippedExtensions: result.skippedExtensions,
+          failedExtensions: result.failedExtensions,
+          downloadResult: result.downloadResult,
+          installResult: {
+            total: result.installResult.total,
+            successful: result.installResult.successful,
+            skipped: result.installResult.skipped,
+            failed: result.installResult.failed,
+            elapsedMs: result.installResult.elapsedMs,
+            results: result.installResult.results.map((r) => ({
+              extensionId: r.task.extensionId,
+              vsixPath: r.task.vsixFile?.path,
+              version: r.task.targetVersion,
+              success: r.success,
+              skipped: r.skipped,
+              error: r.error,
+              elapsedMs: r.elapsedMs,
+            })),
+          },
+          errors: result.errors,
+        };
+
+        await fs.writeJson(options.summary, summaryData, { spaces: 2 });
+        if (!options.quiet) {
+          p.log.success(`📄 Summary written to: ${options.summary}`);
+        }
+      } catch (error) {
+        p.log.warn(
+          `⚠️ Failed to write summary: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  } catch (error) {
+    spinner.stop("❌ Installation failed", 1);
+    throw error;
+  }
+
+  p.outro("✅ List installation completed!");
+}
+
+async function resolveEditor(options: InstallOptions): Promise<"vscode" | "cursor"> {
+  let editor = options.editor as "vscode" | "cursor" | "auto" | undefined;
+
+  if (!editor || editor === "auto") {
+    const editorService = getEditorService();
+    const availableEditors = editorService.getAvailableEditors();
+
+    if (availableEditors.length === 0) {
+      p.log.error("❌ No editors found. Please install VS Code or Cursor.");
+      p.log.info("💡 Install VS Code: https://code.visualstudio.com/");
+      p.log.info("💡 Install Cursor: https://cursor.sh/");
+      process.exit(1);
+    }
+
+    if (availableEditors.length === 1) {
+      const detected = availableEditors[0];
+      p.log.info(`🔍 Auto-detected ${detected.displayName} at ${detected.binaryPath}`);
+      return detected.name;
+    }
+
+    // Multiple editors available
+    const choices = availableEditors.map((editor) => ({
+      value: editor.name,
+      label: `${editor.displayName} (${editor.binaryPath})${getIdentityBadge(editor.name, editor.binaryPath)}`,
+    }));
+
+    if (options.quiet || options.json) {
+      // Non-interactive: prefer Cursor else VS Code
+      const cursor = availableEditors.find((e) => e.name === "cursor");
+      return (cursor || availableEditors[0]).name;
+    }
+
+    const result = await p.select({
+      message: "Multiple editors found. Select target editor:",
+      options: choices,
+    });
+
+    if (p.isCancel(result)) {
+      p.cancel("Operation cancelled.");
+      process.exit(0);
+    }
+
+    editor = result as "vscode" | "cursor";
+  }
+
+  return editor;
+}
+
+async function resolveEditorBinary(
+  editor: "vscode" | "cursor",
+  options: InstallOptions,
+): Promise<string> {
+  const editorService = getEditorService();
+
+  // Use explicit binary path if provided
+  const explicitPath = editor === "vscode" ? options.codeBin : options.cursorBin;
+
+  try {
+    return editorService.resolveEditorBinary(
+      editor,
+      explicitPath,
+      Boolean(options.allowMismatchedBinary),
+    );
+  } catch (error) {
+    p.log.error(`❌ ${error instanceof Error ? error.message : String(error)}`);
+
+    // Show available editors for troubleshooting
+    const availableEditors = editorService.getAvailableEditors();
+    if (availableEditors.length > 0) {
+      p.log.info("📋 Available editors:");
+      availableEditors.forEach((editor) => {
+        p.log.info(`  • ${editor.displayName}: ${editor.binaryPath}`);
+      });
+    }
+
+    process.exit(1);
+  }
+}
+
+// Lightweight UI entrypoints for interactive launcher
+export async function runInstallVsixUI(options: InstallOptions) {
+  options.vsix = options.vsix || ""; // Trigger interactive single VSIX mode
+  await installSingleVsix(options);
+}
+
+export async function runInstallVsixDirUI(options: InstallOptions) {
+  // Leave vsixDir undefined to prompt for directory interactively
+  await installFromVsixDirectory(options);
+}
+
+export async function runInstallFromListUI(options: InstallOptions) {
+  options.file = options.file || ""; // Trigger interactive list mode
+  await installFromList(options);
+}

--- a/src/commands/interactive.ts
+++ b/src/commands/interactive.ts
@@ -14,6 +14,9 @@ export async function runInteractive(config: Config) {
         label: "Download multiple extensions from JSON collection (URLs + versions)",
       },
       { value: "from-list", label: "Download from exported list (txt / extensions.json)" },
+      { value: "install-vsix-single", label: "Install single VSIX file into VS Code/Cursor" },
+      { value: "install-vsix-dir", label: "Install all VSIX files from directory" },
+      { value: "install-list", label: "Install extensions from list into VS Code/Cursor" },
       { value: "export", label: "Export installed extensions to (txt / extensions.json)" },
       { value: "versions", label: "Show extension versions for extension URL" },
       { value: "quit", label: "Quit" },
@@ -49,6 +52,21 @@ export async function runInteractive(config: Config) {
     case "versions": {
       const { listVersions } = await import("./versions");
       await listVersions({ ...config });
+      break;
+    }
+    case "install-vsix-single": {
+      const { runInstallVsixUI } = await import("./install");
+      await runInstallVsixUI({ ...config });
+      break;
+    }
+    case "install-vsix-dir": {
+      const { runInstallVsixDirUI } = await import("./install");
+      await runInstallVsixDirUI({ ...config });
+      break;
+    }
+    case "install-list": {
+      const { runInstallFromListUI } = await import("./install");
+      await runInstallFromListUI({ ...config });
       break;
     }
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -173,6 +173,17 @@ export function convertCliToConfig(cliArgs: Record<string, unknown>): PartialCon
     preRelease: "preRelease",
     checksum: "checksum",
     editor: "editor",
+
+    // Install options
+    installParallel: "installParallel",
+    installRetry: "installRetry",
+    installRetryDelay: "installRetryDelay",
+    skipInstalled: "skipInstalled",
+    forceReinstall: "forceReinstall",
+    dryRun: "dryRun",
+    allowMismatchedBinary: "allowMismatchedBinary",
+    codeBin: "codeBin",
+    cursorBin: "cursorBin",
   };
 
   for (const [cliKey, configKey] of Object.entries(cliMap)) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -40,6 +40,19 @@ export const ConfigSchema = z.object({
 
   // Workspace settings
   editor: z.enum(["vscode", "cursor", "auto"]).default("auto"),
+
+  // Install settings
+  installParallel: z.number().int().min(1).max(20).default(1),
+  installRetry: z.number().int().min(0).max(10).default(2),
+  installRetryDelay: z.number().int().min(0).max(30000).default(1000), // ms
+  skipInstalled: z.boolean().default(false),
+  forceReinstall: z.boolean().default(false),
+  dryRun: z.boolean().default(false),
+  allowMismatchedBinary: z.boolean().default(false),
+
+  // Editor binary paths
+  codeBin: z.string().optional(),
+  cursorBin: z.string().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -70,6 +83,19 @@ export const ENV_VAR_MAP = {
   VSIX_USER_AGENT: "userAgent",
   VSIX_PROGRESS_INTERVAL: "progressUpdateInterval",
   VSIX_EDITOR: "editor",
+
+  // Install settings
+  VSIX_INSTALL_PARALLEL: "installParallel",
+  VSIX_INSTALL_RETRY: "installRetry",
+  VSIX_INSTALL_RETRY_DELAY: "installRetryDelay",
+  VSIX_SKIP_INSTALLED: "skipInstalled",
+  VSIX_FORCE_REINSTALL: "forceReinstall",
+  VSIX_DRY_RUN: "dryRun",
+  VSIX_ALLOW_MISMATCHED_BINARY: "allowMismatchedBinary",
+
+  // Editor binary paths
+  VSIX_CODE_BIN: "codeBin",
+  VSIX_CURSOR_BIN: "cursorBin",
 } as const;
 
 /**

--- a/src/core/errors/index.ts
+++ b/src/core/errors/index.ts
@@ -2,6 +2,7 @@
 
 // Core error types and base classes
 export * from "./types";
+export { InstallError } from "./types";
 
 // Predefined error definitions and factory functions
 export * from "./definitions";

--- a/src/core/errors/types.ts
+++ b/src/core/errors/types.ts
@@ -268,6 +268,28 @@ export class DownloadError extends VsixError {
 }
 
 /**
+ * Install-specific errors
+ */
+export class InstallError extends VsixError {
+  constructor(
+    message: string,
+    code: string,
+    suggestions: ErrorSuggestion[] = [],
+    metadata?: Record<string, unknown>,
+  ) {
+    super({
+      code,
+      category: ErrorCategory.SYSTEM,
+      severity: ErrorSeverity.HIGH,
+      title: "Install Error",
+      message,
+      suggestions,
+      metadata,
+    });
+  }
+}
+
+/**
  * User input errors
  */
 export class UserInputError extends VsixError {

--- a/src/features/install/index.ts
+++ b/src/features/install/index.ts
@@ -1,0 +1,23 @@
+// Install feature main exports
+export { EditorCliService, getEditorService } from "./services/editorCliService";
+export type { EditorInfo, InstalledExtension, InstallResult } from "./services/editorCliService";
+
+export { VsixScannerService, getVsixScanner } from "./services/vsixScannerService";
+export type { VsixFile, ScanResult } from "./services/vsixScannerService";
+
+export { InstallService, getInstallService } from "./services/installService";
+export type {
+  InstallOptions,
+  InstallTask,
+  InstallTaskResult,
+  BulkInstallResult,
+} from "./services/installService";
+
+export {
+  InstallFromListService,
+  getInstallFromListService,
+} from "./services/installFromListService";
+export type {
+  InstallFromListOptions,
+  InstallFromListResult,
+} from "./services/installFromListService";

--- a/src/features/install/services/editorCliService.ts
+++ b/src/features/install/services/editorCliService.ts
@@ -1,0 +1,590 @@
+import { spawn, spawnSync } from "child_process";
+import fs from "fs-extra";
+import os from "os";
+import { InstallError } from "../../../core/errors";
+
+export interface EditorInfo {
+  name: "vscode" | "cursor";
+  displayName: string;
+  binaryPath: string;
+  isAvailable: boolean;
+}
+
+export interface InstalledExtension {
+  id: string;
+  version: string;
+  displayName?: string;
+}
+
+export interface InstallResult {
+  success: boolean;
+  extensionId?: string;
+  error?: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode: number;
+}
+
+/**
+ * Service for managing VS Code/Cursor CLI operations
+ */
+export class EditorCliService {
+  private editors: Map<string, EditorInfo> = new Map();
+
+  constructor() {
+    this.initializeEditors();
+  }
+
+  /**
+   * Initialize available editors by searching common installation paths
+   */
+  private initializeEditors(): void {
+    const platform = os.platform();
+    const homeDir = os.homedir();
+
+    // Define search paths for each platform
+    const searchPaths = this.getEditorSearchPaths(platform, homeDir);
+
+    for (const [editorName, paths] of Object.entries(searchPaths)) {
+      const binaryPath = this.findEditorBinary(editorName as "vscode" | "cursor", paths);
+      const isAvailable = binaryPath ? this.verifyEditorBinary(binaryPath) : false;
+
+      this.editors.set(editorName, {
+        name: editorName as "vscode" | "cursor",
+        displayName: editorName === "vscode" ? "VS Code" : "Cursor",
+        binaryPath: binaryPath || "",
+        isAvailable,
+      });
+    }
+  }
+
+  /**
+   * Get search paths for editors on different platforms
+   */
+  private getEditorSearchPaths(platform: string, homeDir: string): Record<string, string[]> {
+    const paths: Record<string, string[]> = {
+      vscode: [],
+      cursor: [],
+    };
+
+    if (platform === "darwin") {
+      // macOS paths
+      paths.vscode = [
+        "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+        `${homeDir}/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`,
+        "/usr/local/bin/code",
+        "/opt/homebrew/bin/code",
+      ];
+      paths.cursor = [
+        "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+        `${homeDir}/Applications/Cursor.app/Contents/Resources/app/bin/cursor`,
+        "/usr/local/bin/cursor",
+        "/opt/homebrew/bin/cursor",
+      ];
+    } else if (platform === "win32") {
+      // Windows paths
+      const programFiles = process.env.PROGRAMFILES || "C:\\Program Files";
+      const programFilesX86 = process.env["PROGRAMFILES(X86)"] || "C:\\Program Files (x86)";
+      const localAppData = process.env.LOCALAPPDATA || `${homeDir}\\AppData\\Local`;
+
+      paths.vscode = [
+        `${programFiles}\\Microsoft VS Code\\bin\\code.cmd`,
+        `${programFilesX86}\\Microsoft VS Code\\bin\\code.cmd`,
+        `${localAppData}\\Programs\\Microsoft VS Code\\bin\\code.cmd`,
+      ];
+      paths.cursor = [
+        `${localAppData}\\Programs\\cursor\\resources\\app\\bin\\cursor.cmd`,
+        `${programFiles}\\Cursor\\resources\\app\\bin\\cursor.cmd`,
+      ];
+    } else {
+      // Linux and others
+      paths.vscode = [
+        "/usr/bin/code",
+        "/usr/local/bin/code",
+        "/snap/bin/code",
+        `${homeDir}/.local/bin/code`,
+      ];
+      paths.cursor = [
+        "/usr/bin/cursor",
+        "/usr/local/bin/cursor",
+        "/snap/bin/cursor",
+        `${homeDir}/.local/bin/cursor`,
+      ];
+    }
+
+    return paths;
+  }
+
+  /**
+   * Find editor binary by checking search paths
+   */
+  private findEditorBinary(editor: "vscode" | "cursor", searchPaths: string[]): string | null {
+    // 1) Prefer well-known explicit paths for the target editor
+    for (const searchPath of searchPaths) {
+      if (fs.existsSync(searchPath)) {
+        const real = this.resolveRealPath(searchPath);
+        const identity = this.detectEditorIdentityFromPath(real);
+        if (identity === editor) {
+          return real;
+        }
+      }
+    }
+
+    // 2) Fallback to PATH command, but validate identity
+    const commandName = editor === "vscode" ? "code" : "cursor";
+    const absFromPath = this.resolveCommandAbsolutePath(commandName);
+    if (absFromPath) {
+      const real = this.resolveRealPath(absFromPath);
+      const identity = this.detectEditorIdentityFromPath(real);
+      if (identity === editor) {
+        return real;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Check if a command is available in PATH
+   */
+  private isCommandAvailable(command: string): boolean {
+    try {
+      const result = spawnSync(command, ["--version"], {
+        stdio: "pipe",
+        timeout: 5000,
+      });
+      return result.status === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Resolve command name to absolute path using PATH search
+   */
+  private resolveCommandAbsolutePath(command: string): string | null {
+    // If already looks like a path, return realpath
+    if (/[\\/]/.test(command)) {
+      return this.resolveRealPath(command);
+    }
+
+    const pathEnv: string = process.env.PATH || "";
+    const pathSep = process.platform === "win32" ? ";" : ":";
+    const exts = process.platform === "win32" ? [".cmd", ".bat", ".exe", ""] : [""];
+    for (const dir of pathEnv.split(pathSep)) {
+      if (!dir) continue;
+      for (const ext of exts) {
+        const candidate = `${dir}${dir.endsWith("/") || dir.endsWith("\\") ? "" : process.platform === "win32" ? "\\" : "/"}${command}${ext}`;
+        try {
+          if (fs.existsSync(candidate)) {
+            return this.resolveRealPath(candidate);
+          }
+        } catch {
+          // ignore
+        }
+      }
+    }
+    return null;
+  }
+
+  private resolveRealPath(p: string): string {
+    try {
+      return fs.realpathSync(p);
+    } catch {
+      return p;
+    }
+  }
+
+  /**
+   * Best-effort identity detection by installation path
+   */
+  private detectEditorIdentityFromPath(p: string): "vscode" | "cursor" | "unknown" {
+    const lower = p.toLowerCase();
+    // macOS application bundles
+    if (lower.includes("cursor.app")) return "cursor";
+    if (lower.includes("visual studio code.app")) return "vscode";
+
+    // Windows
+    if (lower.endsWith("\\cursor.cmd") || lower.includes("\\cursor\\resources\\app\\bin\\"))
+      return "cursor";
+    if (lower.endsWith("\\code.cmd") || lower.includes("\\microsoft vs code\\bin\\"))
+      return "vscode";
+
+    // Linux and generic
+    // Prefer explicit names in path segments
+    if (/(^|[\\/])cursor([\\/]|$)/.test(lower)) return "cursor";
+    if (/(^|[\\/])code([\\/]|$)/.test(lower)) return "vscode";
+
+    return "unknown";
+  }
+
+  /**
+   * Verify that an editor binary is working
+   */
+  private verifyEditorBinary(binaryPath: string): boolean {
+    try {
+      const result = spawnSync(binaryPath, ["--version"], {
+        stdio: "pipe",
+        timeout: 5000,
+      });
+      return result.status === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get information about available editors
+   */
+  getAvailableEditors(): EditorInfo[] {
+    return Array.from(this.editors.values()).filter((editor) => editor.isAvailable);
+  }
+
+  /**
+   * Get editor info by name
+   */
+  getEditorInfo(name: "vscode" | "cursor"): EditorInfo | null {
+    return this.editors.get(name) || null;
+  }
+
+  /**
+   * Resolve editor binary path with explicit override support
+   */
+  resolveEditorBinary(
+    editor: "vscode" | "cursor" | "auto",
+    explicitPath?: string,
+    allowMismatchedBinary: boolean = false,
+  ): string {
+    // Use explicit path if provided
+    if (explicitPath) {
+      if (!fs.existsSync(explicitPath)) {
+        throw new InstallError(
+          `Explicit editor binary not found: ${explicitPath}`,
+          "INSTALL_BINARY_NOT_FOUND",
+          [
+            { action: "Check path", description: "Verify the binary path is correct" },
+            {
+              action: "Install editor",
+              description: `Install ${editor === "vscode" ? "VS Code" : "Cursor"}`,
+            },
+          ],
+          { editor, explicitPath },
+        );
+      }
+      const real = this.resolveRealPath(explicitPath);
+      const identity = this.detectEditorIdentityFromPath(real);
+      if (
+        !allowMismatchedBinary &&
+        editor !== "auto" &&
+        identity !== "unknown" &&
+        identity !== editor
+      ) {
+        throw new InstallError(
+          `${editor === "vscode" ? "VS Code" : "Cursor"} requested, but binary points to ${identity} (${real})`,
+          "INSTALL_BINARY_MISMATCH",
+          [
+            {
+              action: "Use explicit binary",
+              description:
+                editor === "vscode"
+                  ? 'Pass --code-bin "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"'
+                  : 'Pass --cursor-bin "/Applications/Cursor.app/Contents/Resources/app/bin/cursor"',
+            },
+            {
+              action: "Fix PATH mapping (macOS)",
+              description:
+                'In VS Code: Command Palette → ‘Shell Command: Install "code" command in PATH’, or update /usr/local/bin symlink',
+            },
+            {
+              action: "Override",
+              description: "Use --allow-mismatched-binary to proceed (not recommended)",
+            },
+          ],
+          { editor, binaryPath: real, detected: identity },
+        );
+      }
+      return real;
+    }
+
+    // Auto-detect preferred editor
+    if (editor === "auto") {
+      // Prefer Cursor if available, fallback to VS Code
+      const cursor = this.getEditorInfo("cursor");
+      if (cursor?.isAvailable) {
+        return cursor.binaryPath;
+      }
+
+      const vscode = this.getEditorInfo("vscode");
+      if (vscode?.isAvailable) {
+        return vscode.binaryPath;
+      }
+
+      throw new InstallError(
+        "No editors found. Please install VS Code or Cursor.",
+        "INSTALL_NO_EDITORS",
+        [
+          {
+            action: "Install VS Code",
+            description: "Download from https://code.visualstudio.com/",
+          },
+          { action: "Install Cursor", description: "Download from https://cursor.sh/" },
+          {
+            action: "Set explicit path",
+            description: "Use --code-bin or --cursor-bin to specify binary path",
+          },
+        ],
+        { editor },
+      );
+    }
+
+    // Specific editor requested
+    const editorInfo = this.getEditorInfo(editor);
+    if (!editorInfo?.isAvailable) {
+      throw new InstallError(
+        `${editorInfo?.displayName || editor} is not available`,
+        "INSTALL_EDITOR_NOT_FOUND",
+        [
+          { action: "Install editor", description: `Install ${editorInfo?.displayName || editor}` },
+          { action: "Check PATH", description: "Ensure the editor binary is in your PATH" },
+          {
+            action: "Set explicit path",
+            description: `Use --${editor}-bin to specify binary path`,
+          },
+        ],
+        { editor, availableEditors: this.getAvailableEditors() },
+      );
+    }
+
+    // Final identity validation if possible
+    const detected = this.detectEditorIdentityFromPath(editorInfo.binaryPath);
+    if (!allowMismatchedBinary && detected !== "unknown" && detected !== editor) {
+      throw new InstallError(
+        `${editorInfo.displayName} requested, but resolved binary points to ${detected} (${editorInfo.binaryPath})`,
+        "INSTALL_BINARY_MISMATCH",
+        [
+          {
+            action: "Use explicit binary",
+            description:
+              editor === "vscode"
+                ? 'Pass --code-bin "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"'
+                : 'Pass --cursor-bin "/Applications/Cursor.app/Contents/Resources/app/bin/cursor"',
+          },
+          {
+            action: "Override",
+            description: "Use --allow-mismatched-binary to proceed (not recommended)",
+          },
+        ],
+        { editor, binaryPath: editorInfo.binaryPath, detected },
+      );
+    }
+
+    return editorInfo.binaryPath;
+  }
+
+  /**
+   * Install a VSIX file using the editor CLI
+   */
+  async installVsix(
+    binaryPath: string,
+    vsixPath: string,
+    options: {
+      force?: boolean;
+      timeout?: number;
+    } = {},
+  ): Promise<InstallResult> {
+    const { force = false, timeout = 30000 } = options;
+
+    return new Promise((resolve) => {
+      const args = ["--install-extension", vsixPath];
+      if (force) {
+        args.push("--force");
+      }
+
+      const child = spawn(binaryPath, args, {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout,
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout?.on("data", (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr?.on("data", (data) => {
+        stderr += data.toString();
+      });
+
+      child.on("close", (code) => {
+        const success = code === 0;
+        resolve({
+          success,
+          exitCode: code || 0,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+        });
+      });
+
+      child.on("error", (error) => {
+        resolve({
+          success: false,
+          error: error.message,
+          exitCode: 1,
+          stdout,
+          stderr,
+        });
+      });
+    });
+  }
+
+  /**
+   * List installed extensions using editor CLI
+   */
+  async listInstalledExtensions(binaryPath: string): Promise<InstalledExtension[]> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(binaryPath, ["--list-extensions", "--show-versions"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 10000,
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout?.on("data", (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr?.on("data", (data) => {
+        stderr += data.toString();
+      });
+
+      child.on("close", (code) => {
+        if (code !== 0) {
+          reject(new Error(`Failed to list extensions: ${stderr || stdout}`));
+          return;
+        }
+
+        const extensions = this.parseExtensionListOutput(stdout);
+        resolve(extensions);
+      });
+
+      child.on("error", (error) => {
+        reject(error);
+      });
+    });
+  }
+
+  /**
+   * Parse the output of --list-extensions --show-versions
+   */
+  private parseExtensionListOutput(output: string): InstalledExtension[] {
+    const lines = output
+      .trim()
+      .split("\n")
+      .filter((line) => line.trim());
+    const extensions: InstalledExtension[] = [];
+
+    for (const line of lines) {
+      // Format is typically: publisher.extension@version
+      const atIndex = line.lastIndexOf("@");
+      if (atIndex > 0) {
+        const id = line.substring(0, atIndex);
+        const version = line.substring(atIndex + 1);
+        extensions.push({ id, version });
+      } else {
+        // Fallback for lines without version
+        extensions.push({ id: line, version: "unknown" });
+      }
+    }
+
+    return extensions;
+  }
+
+  /**
+   * Uninstall an extension
+   */
+  async uninstallExtension(binaryPath: string, extensionId: string): Promise<InstallResult> {
+    return new Promise((resolve) => {
+      const child = spawn(binaryPath, ["--uninstall-extension", extensionId], {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 15000,
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout?.on("data", (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr?.on("data", (data) => {
+        stderr += data.toString();
+      });
+
+      child.on("close", (code) => {
+        const success = code === 0;
+        resolve({
+          success,
+          extensionId,
+          exitCode: code || 0,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+        });
+      });
+
+      child.on("error", (error) => {
+        resolve({
+          success: false,
+          extensionId,
+          error: error.message,
+          exitCode: 1,
+          stdout,
+          stderr,
+        });
+      });
+    });
+  }
+
+  /**
+   * Get editor version
+   */
+  async getEditorVersion(binaryPath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(binaryPath, ["--version"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 5000,
+      });
+
+      let stdout = "";
+
+      child.stdout?.on("data", (data) => {
+        stdout += data.toString();
+      });
+
+      child.on("close", (code) => {
+        if (code !== 0) {
+          reject(new Error("Failed to get editor version"));
+          return;
+        }
+
+        const version = stdout.trim().split("\n")[0] || "unknown";
+        resolve(version);
+      });
+
+      child.on("error", (error) => {
+        reject(error);
+      });
+    });
+  }
+}
+
+// Global instance
+let globalEditorService: EditorCliService | null = null;
+
+export function getEditorService(): EditorCliService {
+  if (!globalEditorService) {
+    globalEditorService = new EditorCliService();
+  }
+  return globalEditorService;
+}

--- a/src/features/install/services/installService.ts
+++ b/src/features/install/services/installService.ts
@@ -1,0 +1,334 @@
+import { getEditorService, InstallResult } from "./editorCliService";
+import { VsixFile } from "./vsixScannerService";
+
+export interface InstallOptions {
+  dryRun?: boolean;
+  forceReinstall?: boolean;
+  skipInstalled?: boolean;
+  parallel?: number;
+  retry?: number;
+  retryDelay?: number;
+  timeout?: number;
+  quiet?: boolean;
+}
+
+export interface InstallTask {
+  vsixFile: VsixFile;
+  extensionId?: string;
+  targetVersion?: string;
+}
+
+export interface InstallTaskResult {
+  task: InstallTask;
+  success: boolean;
+  skipped?: boolean;
+  error?: string;
+  installResult?: InstallResult;
+  elapsedMs: number;
+  startTime: number;
+}
+
+export interface BulkInstallResult {
+  total: number;
+  successful: number;
+  skipped: number;
+  failed: number;
+  results: InstallTaskResult[];
+  elapsedMs: number;
+}
+
+/**
+ * Service for managing VSIX installation operations
+ */
+export class InstallService {
+  private editorService = getEditorService();
+
+  /**
+   * Install a single VSIX file
+   */
+  async installSingleVsix(
+    binaryPath: string,
+    vsixPath: string,
+    options: InstallOptions = {},
+  ): Promise<InstallResult> {
+    try {
+      if (options.dryRun) {
+        return {
+          success: true,
+          exitCode: 0,
+          stdout: `[DRY RUN] Would install ${vsixPath}`,
+        };
+      }
+
+      const result = await this.editorService.installVsix(binaryPath, vsixPath, {
+        force: options.forceReinstall,
+        timeout: options.timeout,
+      });
+
+      return result;
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        exitCode: 1,
+      };
+    }
+  }
+
+  /**
+   * Install multiple VSIX files with retry logic and progress tracking
+   */
+  async installBulkVsix(
+    binaryPath: string,
+    tasks: InstallTask[],
+    options: InstallOptions = {},
+    progressCallback?: (result: InstallTaskResult) => void,
+  ): Promise<BulkInstallResult> {
+    const startTime = Date.now();
+    const results: InstallTaskResult[] = [];
+    let successful = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    const { skipInstalled = false, parallel = 1, dryRun = false } = options;
+
+    // Get currently installed extensions for skip logic
+    let installedExtensions: Map<string, string> | null = null;
+    if (skipInstalled && !dryRun) {
+      try {
+        const installed = await this.editorService.listInstalledExtensions(binaryPath);
+        installedExtensions = new Map(installed.map((ext) => [ext.id, ext.version]));
+      } catch {
+        // If we can't get installed extensions, continue without skip logic
+        console.warn("Warning: Could not retrieve installed extensions for skip logic");
+      }
+    }
+
+    // Process tasks
+    if (parallel <= 1) {
+      // Sequential processing
+      for (const task of tasks) {
+        const result = await this.processInstallTask(
+          binaryPath,
+          task,
+          options,
+          installedExtensions,
+        );
+        results.push(result);
+
+        if (result.success) successful++;
+        else if (result.skipped) skipped++;
+        else failed++;
+
+        if (progressCallback) {
+          progressCallback(result);
+        }
+      }
+    } else {
+      // Parallel processing with concurrency limit
+      const batches = this.chunkArray(tasks, parallel);
+
+      for (const batch of batches) {
+        const batchPromises = batch.map((task) =>
+          this.processInstallTask(binaryPath, task, options, installedExtensions),
+        );
+
+        const batchResults = await Promise.all(batchPromises);
+
+        for (const result of batchResults) {
+          results.push(result);
+
+          if (result.success) successful++;
+          else if (result.skipped) skipped++;
+          else failed++;
+
+          if (progressCallback) {
+            progressCallback(result);
+          }
+        }
+      }
+    }
+
+    return {
+      total: tasks.length,
+      successful,
+      skipped,
+      failed,
+      results,
+      elapsedMs: Date.now() - startTime,
+    };
+  }
+
+  /**
+   * Process a single install task with retry logic
+   */
+  private async processInstallTask(
+    binaryPath: string,
+    task: InstallTask,
+    options: InstallOptions,
+    installedExtensions?: Map<string, string> | null,
+  ): Promise<InstallTaskResult> {
+    const startTime = Date.now();
+    const {
+      skipInstalled = false,
+      forceReinstall = false,
+      retry = 2,
+      retryDelay = 1000,
+      dryRun = false,
+      timeout,
+    } = options;
+
+    // Check if extension is already installed (skip logic)
+    if (skipInstalled && installedExtensions && task.extensionId) {
+      const installedVersion = installedExtensions.get(task.extensionId);
+      if (installedVersion && !forceReinstall) {
+        // Check if versions match (if we know the target version)
+        if (!task.targetVersion || installedVersion === task.targetVersion) {
+          return {
+            task,
+            success: true,
+            skipped: true,
+            elapsedMs: Date.now() - startTime,
+            startTime,
+          };
+        }
+      }
+    }
+
+    // Attempt installation with retries
+    let lastError: string | undefined;
+
+    for (let attempt = 0; attempt <= retry; attempt++) {
+      try {
+        const result = await this.installSingleVsix(binaryPath, task.vsixFile.path, {
+          dryRun,
+          forceReinstall,
+          timeout,
+        });
+
+        return {
+          task,
+          success: result.success,
+          installResult: result,
+          error: result.error,
+          elapsedMs: Date.now() - startTime,
+          startTime,
+        };
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+
+        if (attempt < retry) {
+          // Wait before retry
+          await this.delay(retryDelay * Math.pow(2, attempt)); // Exponential backoff
+        }
+      }
+    }
+
+    // All retries failed
+    return {
+      task,
+      success: false,
+      error: lastError,
+      elapsedMs: Date.now() - startTime,
+      startTime,
+    };
+  }
+
+  /**
+   * Check if an extension is already installed
+   */
+  async isExtensionInstalled(
+    binaryPath: string,
+    extensionId: string,
+  ): Promise<{ installed: boolean; version?: string }> {
+    try {
+      const installed = await this.editorService.listInstalledExtensions(binaryPath);
+      const extension = installed.find((ext) => ext.id === extensionId);
+
+      return {
+        installed: !!extension,
+        version: extension?.version,
+      };
+    } catch {
+      // If we can't check, assume not installed to be safe
+      return { installed: false };
+    }
+  }
+
+  /**
+   * Get installed extensions map
+   */
+  async getInstalledExtensions(binaryPath: string): Promise<Map<string, string>> {
+    try {
+      const installed = await this.editorService.listInstalledExtensions(binaryPath);
+      return new Map(installed.map((ext) => [ext.id, ext.version]));
+    } catch {
+      return new Map();
+    }
+  }
+
+  /**
+   * Uninstall an extension
+   */
+  async uninstallExtension(binaryPath: string, extensionId: string): Promise<InstallResult> {
+    return this.editorService.uninstallExtension(binaryPath, extensionId);
+  }
+
+  /**
+   * Validate installation prerequisites
+   */
+  async validatePrerequisites(binaryPath: string): Promise<{ valid: boolean; errors: string[] }> {
+    const errors: string[] = [];
+
+    try {
+      // If binaryPath is an absolute/path-like string, check on disk
+      const isPathLike = /[\\/]/.test(binaryPath);
+      if (isPathLike) {
+        const fs = await import("fs-extra");
+        if (!(await fs.pathExists(binaryPath))) {
+          errors.push(`Editor binary not found: ${binaryPath}`);
+        }
+      }
+
+      // Try to get version to verify it's working (works for PATH commands too)
+      await this.editorService.getEditorVersion(binaryPath);
+    } catch (error) {
+      errors.push(
+        `Editor binary not accessible: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+
+  /**
+   * Utility: Split array into chunks
+   */
+  private chunkArray<T>(array: T[], chunkSize: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < array.length; i += chunkSize) {
+      chunks.push(array.slice(i, i + chunkSize));
+    }
+    return chunks;
+  }
+
+  /**
+   * Utility: Delay helper
+   */
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+// Global instance
+let globalInstallService: InstallService | null = null;
+
+export function getInstallService(): InstallService {
+  if (!globalInstallService) {
+    globalInstallService = new InstallService();
+  }
+  return globalInstallService;
+}

--- a/src/features/install/services/vsixScannerService.ts
+++ b/src/features/install/services/vsixScannerService.ts
@@ -1,0 +1,344 @@
+import fs from "fs-extra";
+import path from "path";
+import { ValidationError } from "../../../core/errors";
+
+export interface VsixFile {
+  path: string;
+  filename: string;
+  size: number;
+  modified: Date;
+  isValid: boolean;
+  error?: string;
+  extensionId?: string;
+  version?: string;
+}
+
+export interface ScanResult {
+  totalFiles: number;
+  validVsixFiles: VsixFile[];
+  invalidFiles: VsixFile[];
+  errors: string[];
+}
+
+/**
+ * Service for scanning and validating VSIX files
+ */
+export class VsixScannerService {
+  /**
+   * Scan a directory for VSIX files recursively
+   */
+  async scanDirectory(
+    directory: string,
+    options: {
+      recursive?: boolean;
+      validateFiles?: boolean;
+      maxDepth?: number;
+    } = {},
+  ): Promise<ScanResult> {
+    const { recursive = true, validateFiles = true, maxDepth = 10 } = options;
+
+    if (!(await fs.pathExists(directory))) {
+      throw new ValidationError(
+        `Directory does not exist: ${directory}`,
+        "SCAN_DIR_NOT_FOUND",
+        [
+          { action: "Check path", description: "Verify the directory path is correct" },
+          { action: "Create directory", description: "Create the directory if it should exist" },
+        ],
+        { directory },
+      );
+    }
+
+    const stat = await fs.stat(directory);
+    if (!stat.isDirectory()) {
+      throw new ValidationError(
+        `Path is not a directory: ${directory}`,
+        "SCAN_NOT_DIRECTORY",
+        [
+          { action: "Check path", description: "Ensure the path points to a directory" },
+          {
+            action: "Use file path",
+            description: "Use --vsix for single files instead of --vsix-dir",
+          },
+        ],
+        { directory },
+      );
+    }
+
+    const result: ScanResult = {
+      totalFiles: 0,
+      validVsixFiles: [],
+      invalidFiles: [],
+      errors: [],
+    };
+
+    try {
+      await this.scanDirectoryRecursive(directory, result, {
+        recursive,
+        validateFiles,
+        maxDepth,
+        currentDepth: 0,
+      });
+    } catch (error) {
+      result.errors.push(`Scan error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    return result;
+  }
+
+  /**
+   * Recursively scan directory for VSIX files
+   */
+  private async scanDirectoryRecursive(
+    directory: string,
+    result: ScanResult,
+    options: {
+      recursive: boolean;
+      validateFiles: boolean;
+      maxDepth: number;
+      currentDepth: number;
+    },
+  ): Promise<void> {
+    const { recursive, validateFiles, maxDepth, currentDepth } = options;
+
+    if (currentDepth > maxDepth) {
+      return; // Prevent infinite recursion
+    }
+
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        if (recursive) {
+          await this.scanDirectoryRecursive(fullPath, result, {
+            ...options,
+            currentDepth: currentDepth + 1,
+          });
+        }
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".vsix")) {
+        result.totalFiles++;
+        const vsixFile = await this.processVsixFile(fullPath, validateFiles);
+        if (vsixFile.isValid) {
+          result.validVsixFiles.push(vsixFile);
+        } else {
+          result.invalidFiles.push(vsixFile);
+        }
+      }
+    }
+  }
+
+  /**
+   * Process a single VSIX file
+   */
+  private async processVsixFile(filePath: string, validate: boolean): Promise<VsixFile> {
+    const filename = path.basename(filePath);
+
+    try {
+      const stats = await fs.stat(filePath);
+
+      const vsixFile: VsixFile = {
+        path: filePath,
+        filename,
+        size: stats.size,
+        modified: stats.mtime,
+        isValid: false,
+      };
+
+      // Basic validation
+      if (stats.size === 0) {
+        vsixFile.error = "File is empty";
+        return vsixFile;
+      }
+
+      if (stats.size < 1024) {
+        vsixFile.error = "File is too small to be a valid VSIX";
+        return vsixFile;
+      }
+
+      // Try to extract extension info from filename
+      const extracted = this.extractExtensionInfoFromFilename(filename);
+      if (extracted) {
+        vsixFile.extensionId = extracted.id;
+        vsixFile.version = extracted.version;
+      }
+
+      // Optional deep validation
+      if (validate) {
+        const validationResult = await this.validateVsixFile(filePath);
+        if (!validationResult.isValid) {
+          vsixFile.error = validationResult.error;
+          return vsixFile;
+        }
+      }
+
+      vsixFile.isValid = true;
+      return vsixFile;
+    } catch (error) {
+      return {
+        path: filePath,
+        filename,
+        size: 0,
+        modified: new Date(),
+        isValid: false,
+        error: `Failed to process file: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  /**
+   * Extract extension ID and version from filename
+   * Expected patterns:
+   * - publisher.extension-version.vsix
+   * - publisher-extension-vversion.vsix
+   * - publisher.extension.vsix (no version)
+   */
+  private extractExtensionInfoFromFilename(
+    filename: string,
+  ): { id: string; version?: string } | null {
+    const nameWithoutExt = filename.replace(/\.vsix$/i, "");
+
+    // Try pattern: publisher.extension-version
+    const dashMatch = nameWithoutExt.match(/^(.+)-(.+)$/);
+    if (dashMatch) {
+      const potentialId = dashMatch[1];
+      const potentialVersion = dashMatch[2];
+
+      // Check if potentialId looks like publisher.extension
+      if (potentialId.includes(".")) {
+        // Validate version format
+        if (this.isValidVersion(potentialVersion)) {
+          return { id: potentialId, version: potentialVersion };
+        }
+      }
+    }
+
+    // Try pattern: just publisher.extension (no version)
+    if (nameWithoutExt.includes(".")) {
+      return { id: nameWithoutExt };
+    }
+
+    return null;
+  }
+
+  /**
+   * Basic version validation
+   */
+  private isValidVersion(version: string): boolean {
+    // Allow semantic versions, dates, or other common patterns
+    return /^\d+[\d\.\-_a-zA-Z]*$/.test(version);
+  }
+
+  /**
+   * Validate VSIX file structure (basic checks)
+   */
+  private async validateVsixFile(filePath: string): Promise<{ isValid: boolean; error?: string }> {
+    try {
+      // Check if file is readable
+      const buffer = await fs.readFile(filePath);
+
+      // VSIX files are ZIP archives, check for ZIP signature
+      if (buffer.length < 4) {
+        return { isValid: false, error: "File too small" };
+      }
+
+      // ZIP files start with PK\x03\x04
+      const zipSignature = buffer.readUInt32LE(0);
+      if (zipSignature !== 0x04034b50) {
+        return { isValid: false, error: "Not a valid ZIP archive (missing ZIP signature)" };
+      }
+
+      // Additional checks could include:
+      // - Checking for [Content_Types].xml
+      // - Validating extension manifest
+      // But for now, basic ZIP signature check is sufficient
+
+      return { isValid: true };
+    } catch (error) {
+      return {
+        isValid: false,
+        error: `Validation failed: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  /**
+   * Find best matching VSIX file for an extension ID
+   */
+  findBestMatchForExtension(
+    vsixFiles: VsixFile[],
+    extensionId: string,
+    targetVersion?: string,
+  ): VsixFile | null {
+    // Filter by extension ID
+    const matchingFiles = vsixFiles.filter((file) => file.extensionId === extensionId);
+
+    if (matchingFiles.length === 0) {
+      return null;
+    }
+
+    if (matchingFiles.length === 1) {
+      return matchingFiles[0];
+    }
+
+    // Multiple matches - try to find version match
+    if (targetVersion) {
+      const versionMatch = matchingFiles.find((file) => file.version === targetVersion);
+      if (versionMatch) {
+        return versionMatch;
+      }
+    }
+
+    // Return the most recently modified file
+    return matchingFiles.sort((a, b) => b.modified.getTime() - a.modified.getTime())[0];
+  }
+
+  /**
+   * Group VSIX files by extension ID
+   */
+  groupByExtensionId(vsixFiles: VsixFile[]): Map<string, VsixFile[]> {
+    const groups = new Map<string, VsixFile[]>();
+
+    for (const file of vsixFiles) {
+      if (file.extensionId) {
+        const existing = groups.get(file.extensionId) || [];
+        existing.push(file);
+        groups.set(file.extensionId, existing);
+      }
+    }
+
+    return groups;
+  }
+
+  /**
+   * Get scan summary
+   */
+  getScanSummary(result: ScanResult): {
+    total: number;
+    valid: number;
+    invalid: number;
+    uniqueExtensions: number;
+  } {
+    const uniqueExtensions = new Set(
+      result.validVsixFiles.map((f) => f.extensionId).filter(Boolean),
+    ).size;
+
+    return {
+      total: result.totalFiles,
+      valid: result.validVsixFiles.length,
+      invalid: result.invalidFiles.length,
+      uniqueExtensions,
+    };
+  }
+}
+
+// Global instance
+let globalVsixScanner: VsixScannerService | null = null;
+
+export function getVsixScanner(): VsixScannerService {
+  if (!globalVsixScanner) {
+    globalVsixScanner = new VsixScannerService();
+  }
+  return globalVsixScanner;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ program
   .option("--cache-dir <path>", "Cache directory for downloads (overrides output)")
   .option("--checksum", "Generate SHA256 checksum for downloaded files", false)
   .option("--verify-checksum <hash>", "Verify downloaded file against provided SHA256 hash")
+  .option("--install-after", "Install downloaded extensions after successful downloads", false)
   .action(async (opts) => {
     await withConfigAndErrorHandling(async (config, options) => {
       await downloadVsix({ ...options, ...config });
@@ -105,7 +106,6 @@ program
 
 program
   .command("from-list")
-  .alias("install")
   .description("Download extensions from a list file")
   .option("-f, --file <path>", "Path to extensions list file")
   .option("-o, --output <path>", "Output directory (default: ./downloads)")
@@ -123,10 +123,47 @@ program
   .option("--filename-template <template>", "Custom filename template")
   .option("--cache-dir <path>", "Cache directory for downloads")
   .option("--checksum", "Generate SHA256 checksum for downloaded files", false)
+  .option(
+    "--install",
+    "Install extensions after downloading (requires --download-missing behavior)",
+    false,
+  )
+  .option("--download-only", "Download only, do not install (default behavior)", false)
   .action(async (opts) => {
     await withConfigAndErrorHandling(async (config, options) => {
       const { fromList } = await import("./commands/fromList");
       await fromList({ ...options, ...config });
+    }, opts);
+  });
+
+program
+  .command("install")
+  .description("Install VSIX files or extensions from lists into VS Code/Cursor")
+  .option("--vsix <path>", "Single VSIX file to install")
+  .option("--vsix-dir <paths...>", "Directories to scan for VSIX files (recursive)")
+  .option("-f, --file <path>", "Extension list file (.txt or extensions.json) to install from")
+  .option("--download-missing", "Download missing extensions when installing from list", false)
+  .option("-e, --editor <editor>", "Target editor: vscode|cursor|auto (default: auto)")
+  .option("--code-bin <path>", "Explicit path to VS Code binary")
+  .option("--cursor-bin <path>", "Explicit path to Cursor binary")
+  .option("--skip-installed", "Skip if same version already installed", false)
+  .option("--force-reinstall", "Force reinstall even if same version", false)
+  .option("--dry-run", "Show what would be installed without making changes", false)
+  .option("--parallel <n>", "Number of parallel installs (default: 1)")
+  .option("--retry <n>", "Number of retry attempts per install")
+  .option("--retry-delay <ms>", "Delay in ms between retries")
+  .option("--quiet", "Reduce output", false)
+  .option("--json", "Machine-readable logs", false)
+  .option("--summary <path>", "Write install summary JSON to the given path")
+  .option(
+    "--allow-mismatched-binary",
+    "Allow proceeding when resolved binary identity mismatches the requested editor",
+    false,
+  )
+  .action(async (opts) => {
+    await withConfigAndErrorHandling(async (config, options) => {
+      const { installExtensions } = await import("./commands/install");
+      await installExtensions({ ...options, ...config });
     }, opts);
   });
 


### PR DESCRIPTION
- Interactive menu: split single VSIX vs directory install; prompt for directory
- Install flow: identity badges (OK/MISMATCH) in editor picker; non-interactive auto-pick
- Mismatch detection: block when code points to Cursor (and vice versa) with override flag
- CLI/config: add --allow-mismatched-binary and VSIX_ALLOW_MISMATCHED_BINARY
- README: document bulk directory install, interactive behavior, mismatch troubleshooting