### PR TITLE
feat: add quick-install command (temp download → install → cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A modern CLI for downloading, exporting, importing, and managing VS Code/Cursor 
 - [Features / Highlights](#features--highlights)
 - [Installation / Getting Started](#installation--getting-started)
 - [Usage / Examples](#usage--examples)
+  - [Quick Install (one-off)](#quick-install-one-off)
   - [Interactive Mode](#interactive-mode)
   - [Single Extension Download](#single-extension-download)
   - [Bulk Download from JSON](#bulk-download-from-json)
@@ -78,6 +79,36 @@ npm run build
 
 ### Usage / Examples
 
+#### Quick Install (one-off)
+
+Download an extension by URL to a temporary folder, install it, then clean up.
+
+```bash
+# Quick install (auto-detect editor; prefers Cursor)
+vsix-extension-manager quick-install \
+  --url "https://marketplace.visualstudio.com/items?itemName=ms-python.python"
+
+# Shorthand alias
+vsix-extension-manager qi --url "https://open-vsx.org/extension/ms-python/python"
+
+# Explicit editor and binary
+vsix-extension-manager qi \
+  --url "https://marketplace.visualstudio.com/items?itemName=Fuzionix.file-tree-extractor" \
+  --editor cursor \
+  --cursor-bin "/Applications/Cursor.app/Contents/Resources/app/bin/cursor"
+
+# Non-interactive output for scripts/CI
+vsix-extension-manager qi --url "..." --quiet --json
+```
+
+Behavior:
+
+- Creates a unique temp directory
+- Downloads latest (or pre-release with --pre-release)
+- Prompts for target editor when multiple are available (quiet/json prefers Cursor)
+- Installs the VSIX
+- Cleans up the temp directory regardless of outcome
+
 #### Quick Start - Install Extensions
 
 ```bash
@@ -109,6 +140,7 @@ vsix-extension-manager
 
 Interactive Mode Menu:
 
+- Quick install by URL (temp download → install → cleanup)
 - Download single extension from marketplace URL
 - Download multiple extensions from JSON collection (URLs + versions)
 - Download from exported list (txt / extensions.json)
@@ -621,6 +653,15 @@ export VSIX_ALLOW_MISMATCHED_BINARY=false # Allow proceeding when binary identit
   - `--quiet` / `--json` (machine-readable)
   - `--summary <path>`: write bulk summary JSON
   - `--install-after`: install downloaded extensions
+
+- Quick-Install:
+  - `--url <url>`: Marketplace or OpenVSX URL
+  - `--editor <vscode|cursor|auto>`: Target editor (default: auto)
+  - `--code-bin <path>` / `--cursor-bin <path>`: Explicit binaries
+  - `--allow-mismatched-binary`: Proceed when PATH alias points to a different editor
+  - `--pre-release`: Prefer pre-release when resolving latest
+  - `--quiet` / `--json`: Non-interactive / machine-readable output
+  - `--dry-run`: Show what would be installed without making changes
 
 - Export-Installed:
   - `--output <path>`

--- a/architecture.md
+++ b/architecture.md
@@ -33,6 +33,7 @@ Layers and responsibilities:
 src/
 ├─ commands/                    # CLI command handlers (UI/Orchestration layer)
 │  ├─ download.ts              # Interactive single & bulk entrypoint
+│  ├─ quickInstall.ts          # One-off: temp download → install → cleanup
 │  ├─ exportInstalled.ts       # Export installed extensions from editors
 │  ├─ fromList.ts              # Download from list formats (txt/json/extensions.json)
 │  ├─ install.ts               # Install VSIX files into editors (supports directory scanning)
@@ -153,6 +154,24 @@ Notes:
 2. Editor detection and binary resolution via `features/install/services/editorCliService`
 3. Installation execution via `features/install/services/installService`
 4. Results surfaced via CLI with progress tracking and error handling
+
+### Quick-Install Flow
+
+1. `commands/quickInstall.ts` collects the URL (and optional editor/bin flags)
+2. Creates a unique temp directory under `os.tmpdir()`
+3. Uses `features/download/downloadSingleExtension` to fetch the VSIX (latest by default)
+4. Resolves target editor via `features/install/services/editorCliService`
+   - Auto-detects; prompts when multiple; quiet/json prefers Cursor
+   - Supports `--code-bin` / `--cursor-bin` and `--allow-mismatched-binary`
+5. Preflight validation via `InstallService.validatePrerequisites`
+6. Shows "Install Details" (paths are middle‑truncated to fit TTY)
+7. On confirmation, installs via `InstallService.installSingleVsix`
+8. Finally, removes the temp directory regardless of success/failure
+
+Notes:
+
+- This command is intentionally non-persistent: no output artifacts remain
+- Behavior mirrors single install’s editor selection and confirmation UX
 
 ## Foundational Modules
 

--- a/src/commands/interactive.ts
+++ b/src/commands/interactive.ts
@@ -8,6 +8,7 @@ export async function runInteractive(config: Config) {
   const choice = await p.select({
     message: "What do you want to do?",
     options: [
+      { value: "quick-install", label: "Quick install by URL (temp download → install → cleanup)" },
       { value: "single", label: "Download single extension from marketplace URL" },
       {
         value: "bulk",
@@ -29,6 +30,11 @@ export async function runInteractive(config: Config) {
   }
 
   switch (choice) {
+    case "quick-install": {
+      const { runQuickInstallUI } = await import("./quickInstall");
+      await runQuickInstallUI({ ...config });
+      break;
+    }
     case "single": {
       const { runSingleDownloadUI } = await import("./download");
       await runSingleDownloadUI({ ...config });

--- a/src/commands/quickInstall.ts
+++ b/src/commands/quickInstall.ts
@@ -1,0 +1,253 @@
+import * as p from "@clack/prompts";
+import os from "os";
+import path from "path";
+import fs from "fs-extra";
+import {
+  downloadSingleExtension,
+  type SingleDownloadRequest,
+  type SingleDownloadResult,
+} from "../features/download";
+import { FileExistsAction } from "../core/filesystem";
+import { ProgressInfo, createProgressBar, formatBytes } from "../core/ui/progress";
+import { shouldUpdateProgress, truncateText, truncateMiddle } from "../core/helpers";
+import { getEditorService, getInstallService } from "../features/install";
+import type { EditorType, SourceRegistry } from "../core/types";
+
+interface QuickInstallOptions {
+  url?: string;
+  editor?: EditorType;
+  codeBin?: string;
+  cursorBin?: string;
+  allowMismatchedBinary?: boolean;
+  preRelease?: boolean;
+  source?: SourceRegistry;
+  quiet?: boolean;
+  json?: boolean;
+  dryRun?: boolean;
+}
+
+export async function quickInstall(options: QuickInstallOptions) {
+  console.clear();
+  p.intro("⚡ VSIX Quick Install");
+
+  // Collect URL if not provided
+  let url = options.url;
+  if (!url) {
+    const urlResult = await p.text({
+      message: "Enter the extension URL (Marketplace or OpenVSX):",
+      validate: (input: string) => (!input.trim() ? "Please enter a valid URL" : undefined),
+    });
+    if (p.isCancel(urlResult)) {
+      p.cancel("Operation cancelled.");
+      process.exit(0);
+    }
+    url = String(urlResult);
+  }
+
+  // Create a unique temp directory for this quick operation
+  const tempDirName = `vsix-quick-install-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const tempDir = path.join(os.tmpdir(), tempDirName);
+
+  const downloadSpinner = p.spinner();
+  let lastUpdate = Date.now();
+
+  const progressWrapper = (progress: ProgressInfo) => {
+    if (options.quiet) return;
+    const now = Date.now();
+    if (!shouldUpdateProgress(lastUpdate, now)) return;
+    const bar = createProgressBar(progress.percentage, 30);
+    downloadSpinner.message(
+      `${bar} ${formatBytes(progress.downloaded)}/${formatBytes(progress.total)}`,
+    );
+    lastUpdate = now;
+  };
+
+  const installSpinner = p.spinner();
+
+  let downloadResult: SingleDownloadResult | null = null;
+  let binPath: string | null = null;
+  let chosenEditor: "vscode" | "cursor" = "cursor";
+
+  try {
+    await fs.ensureDir(tempDir);
+
+    // Download latest by default (prefer stable unless preRelease is true)
+    const request: SingleDownloadRequest = {
+      url: url!,
+      requestedVersion: "latest",
+      preferPreRelease: Boolean(options.preRelease),
+      source: options.source,
+      outputDir: tempDir,
+      fileExistsAction: FileExistsAction.OVERWRITE,
+      quiet: Boolean(options.quiet),
+      progressCallback: options.quiet ? undefined : progressWrapper,
+    };
+
+    if (!options.quiet) {
+      downloadSpinner.start(`Downloading ${truncateText(url!)}...`);
+    }
+    downloadResult = await downloadSingleExtension(request);
+    if (!options.quiet) downloadSpinner.stop("Download complete");
+
+    const downloadedPath =
+      downloadResult.filePath || path.join(downloadResult.outputDir, downloadResult.filename);
+
+    // Resolve editor (interactive selection if multiple, like single install)
+    const editorService = getEditorService();
+    chosenEditor = await resolveEditorForQuick(options);
+    const explicit = chosenEditor === "vscode" ? options.codeBin : options.cursorBin;
+    binPath = editorService.resolveEditorBinary(
+      chosenEditor,
+      explicit,
+      Boolean(options.allowMismatchedBinary),
+    );
+
+    // Preflight check
+    const preflight = await getInstallService().validatePrerequisites(binPath);
+    if (!preflight.valid) {
+      if (!options.quiet) {
+        p.log.error("❌ Preflight checks failed:");
+        preflight.errors.forEach((e) => p.log.error(`  • ${e}`));
+      }
+      process.exit(1);
+    }
+
+    // Show install details and confirm (match single install behavior)
+    const ttyWidth = process.stdout.columns || 80;
+    const baseVsix = path.basename(downloadedPath);
+    const maxLine = Math.max(22, Math.min(ttyWidth - 30, 42));
+    const shortVsix = truncateMiddle(baseVsix, maxLine);
+    const shortBin = truncateMiddle(binPath, maxLine);
+    p.note(`VSIX: ${shortVsix}\nEditor: ${chosenEditor}\nBinary: ${shortBin}`, "Install Details");
+
+    if (!options.quiet && !options.json) {
+      const confirmRes = await p.confirm({
+        message: "Proceed with installation?",
+        initialValue: true,
+      });
+      if (p.isCancel(confirmRes) || !confirmRes) {
+        p.cancel("Installation cancelled.");
+        return;
+      }
+    }
+
+    if (!options.quiet) installSpinner.start("Installing extension...");
+
+    const installResult = await getInstallService().installSingleVsix(binPath, downloadedPath, {
+      dryRun: Boolean(options.dryRun),
+      forceReinstall: false,
+      timeout: 30000,
+    });
+
+    if (installResult.success) {
+      if (!options.quiet) installSpinner.stop("✅ Installed successfully");
+    } else {
+      if (!options.quiet) installSpinner.stop("❌ Installation failed", 1);
+      if (!options.quiet) p.log.error(installResult.error || "Unknown error");
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              ok: false,
+              url,
+              version: downloadResult.resolvedVersion,
+              file: downloadedPath,
+              error: installResult.error,
+            },
+            null,
+            2,
+          ),
+        );
+      }
+      return;
+    }
+
+    if (options.json) {
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            url,
+            version: downloadResult.resolvedVersion,
+            file: downloadedPath,
+            editor: chosenEditor,
+            editorBinary: binPath,
+          },
+          null,
+          2,
+        ),
+      );
+    } else if (!options.quiet) {
+      p.outro("🎉 Quick install completed (temp files cleaned up)");
+    }
+  } finally {
+    // Cleanup temp directory regardless of success
+    try {
+      await fs.remove(tempDir);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
+// Lightweight UI entrypoint for interactive launcher
+export async function runQuickInstallUI(options: QuickInstallOptions) {
+  await quickInstall(options);
+}
+
+// Match single install's editor selection behavior
+function detectIdentityFromPath(pth: string): "vscode" | "cursor" | "unknown" {
+  const lower = pth.toLowerCase();
+  if (lower.includes("cursor.app")) return "cursor";
+  if (lower.includes("visual studio code.app")) return "vscode";
+  if (/(^|[\\/])cursor([\\/]|$)/.test(lower)) return "cursor";
+  if (/(^|[\\/])code([\\/]|$)/.test(lower)) return "vscode";
+  return "unknown";
+}
+
+function getIdentityBadge(expected: "vscode" | "cursor", binaryPath: string): string {
+  const identity = detectIdentityFromPath(binaryPath);
+  if (identity === "unknown") return "";
+  return identity === expected ? " — OK" : " — MISMATCH";
+}
+
+async function resolveEditorForQuick(options: QuickInstallOptions): Promise<"vscode" | "cursor"> {
+  const editorService = getEditorService();
+  const availableEditors = editorService.getAvailableEditors();
+
+  if (options.editor && options.editor !== "auto") {
+    return options.editor;
+  }
+
+  if (availableEditors.length === 0) {
+    throw new Error("No editors found. Please install VS Code or Cursor.");
+  }
+
+  if (availableEditors.length === 1) {
+    const detected = availableEditors[0];
+    if (!options.quiet && !options.json) {
+      p.log.info(`🔍 Auto-detected ${detected.displayName} at ${detected.binaryPath}`);
+    }
+    return detected.name;
+  }
+
+  if (options.quiet || options.json) {
+    const cursor = availableEditors.find((e) => e.name === "cursor");
+    return (cursor || availableEditors[0]).name;
+  }
+
+  const result = await p.select({
+    message: "Multiple editors found. Select target editor:",
+    options: availableEditors.map((editor) => ({
+      value: editor.name,
+      label: `${editor.displayName} (${editor.binaryPath})${getIdentityBadge(editor.name, editor.binaryPath)}`,
+    })),
+  });
+
+  if (p.isCancel(result)) {
+    p.cancel("Operation cancelled.");
+    process.exit(0);
+  }
+
+  return result as "vscode" | "cursor";
+}

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -6,6 +6,16 @@ export function truncateText(text: string, maxLength: number = 30): string {
   return text.slice(0, maxLength - 3) + "...";
 }
 
+// Middle truncation preserving both ends (useful for long paths)
+export function truncateMiddle(text: string, maxLength: number = 80): string {
+  if (text.length <= maxLength) return text;
+  const ellipsis = "...";
+  const keep = Math.max(4, Math.floor((maxLength - ellipsis.length) / 2));
+  const start = text.slice(0, keep);
+  const end = text.slice(-keep);
+  return `${start}${ellipsis}${end}`;
+}
+
 type CliBulk = {
   parallel?: number | string;
   retry?: number | string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,31 @@ program
   });
 
 program
+  .command("quick-install")
+  .alias("qi")
+  .description("Quickly download an extension by URL to a temp dir, install it, then clean up")
+  .option("-u, --url <url>", "Marketplace or OpenVSX URL of the extension")
+  .option("-e, --editor <editor>", "Target editor: vscode|cursor|auto (default: auto)")
+  .option("--code-bin <path>", "Explicit path to VS Code binary")
+  .option("--cursor-bin <path>", "Explicit path to Cursor binary")
+  .option(
+    "--allow-mismatched-binary",
+    "Allow proceeding when resolved binary identity mismatches the requested editor",
+    false,
+  )
+  .option("--pre-release", "Prefer pre-release when resolving 'latest'", false)
+  .option("--source <source>", "Source registry: marketplace|open-vsx|auto (default: auto)")
+  .option("--dry-run", "Show what would be installed without making changes", false)
+  .option("--quiet", "Reduce output", false)
+  .option("--json", "Machine-readable output", false)
+  .action(async (opts) => {
+    await withConfigAndErrorHandling(async (config, options) => {
+      const { quickInstall } = await import("./commands/quickInstall");
+      await quickInstall({ ...options, ...config });
+    }, opts);
+  });
+
+program
   .command("versions")
   .description("List available versions for an extension")
   .option("-u, --url <url>", "Marketplace URL of the extension")


### PR DESCRIPTION
- New command: quick-install (alias: qi) to download VSIX to a temp dir, install, then clean up
- Interactive editor selection mirrors single install; quiet/json prefers Cursor
- Added middle truncation for long paths; compact Install Details
- Wired CLI and interactive menu; documented usage, options, and flow
- Updated README and architecture